### PR TITLE
update to aapt2, update to use compiler_rt always, call updateLinkObjects recursively

### DIFF
--- a/examples/sdl2/android/AndroidManifest.xml
+++ b/examples/sdl2/android/AndroidManifest.xml
@@ -67,8 +67,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-        android:hardwareAccelerated="true"
-        android:debuggable="true">
+        android:hardwareAccelerated="true" >
 
         <!-- Example of setting SDL hints from AndroidManifest.xml:
         <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>


### PR DESCRIPTION
- update to use compiler_rt always
- update to aapt2
- call updateLinkObjects recursively
- remove use of "android:debuggable" in sdl2 example, set that automatically if the app library/binary is targetting .Debug mode

Fixes #8
- aapt2 has the kind of validation I'd expect.