### PR TITLE
bake package_name into the android module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,5 +22,12 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+
+    // Create stub of builtin options.
+    // This is discovered and then replace in src/androidbuild/apk.zig
+    const android_builtin_options = std.Build.addOptions(b);
+    android_builtin_options.addOption([:0]const u8, "package_name", "");
+    module.addImport("android_builtin", android_builtin_options.createModule());
+
     module.linkSystemLibrary("log", .{});
 }

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -29,12 +29,17 @@ adb uninstall "com.zig.minimal"
 
 ### View logs of application
 
-Powershell
+Powershell (app doesn't need to be running)
 ```sh
 adb logcat | Select-String com.zig.minimal:
 ```
 
-Bash
+Bash (app doesn't need running to be running)
+```sh
+adb logcat com.zig.minimal:D *:S
+```
+
+Bash (app must be running, logs everything by the process including modules)
 ```sh
 adb logcat --pid=`adb shell pidof -s com.zig.minimal`
 ```

--- a/examples/sdl2/README.md
+++ b/examples/sdl2/README.md
@@ -35,12 +35,17 @@ adb uninstall "com.zig.sdl2"
 
 ### View logs of application
 
-Powershell
+Powershell (app doesn't need to be running)
 ```sh
 adb logcat | Select-String com.zig.sdl2:
 ```
 
-Bash
+Bash (app doesn't need running to be running)
+```sh
+adb logcat com.zig.sdl2:D *:S
+```
+
+Bash (app must be running, logs everything by the process including modules)
 ```sh
 adb logcat --pid=`adb shell pidof -s com.zig.sdl2`
 ```

--- a/src/androidbuild/builtin_options_update.zig
+++ b/src/androidbuild/builtin_options_update.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const androidbuild = @import("androidbuild.zig");
+const builtin = @import("builtin");
+const Build = std.Build;
+const Step = Build.Step;
+const Options = Build.Step.Options;
+const LazyPath = Build.LazyPath;
+const fs = std.fs;
+const mem = std.mem;
+const assert = std.debug.assert;
+
+/// BuiltinOptionsUpdate will update the *Options
+pub const BuiltinOptionsUpdate = struct {
+    pub const base_id: Step.Id = .custom;
+
+    step: Step,
+
+    options: *Options,
+    package_name_stdout: LazyPath,
+
+    pub fn create(owner: *std.Build, options: *Options, package_name_stdout: LazyPath) void {
+        const builtin_options_update = owner.allocator.create(@This()) catch @panic("OOM");
+        builtin_options_update.* = .{
+            .step = Step.init(.{
+                .id = base_id,
+                .name = androidbuild.runNameContext("builtin_options_update"),
+                .owner = owner,
+                .makeFn = comptime if (std.mem.eql(u8, builtin.zig_version_string, "0.13.0"))
+                    make013
+                else
+                    makeLatest,
+            }),
+            .options = options,
+            .package_name_stdout = package_name_stdout,
+        };
+        // Run step relies on this finishing
+        options.step.dependOn(&builtin_options_update.step);
+        // Depend on package name stdout before running this step
+        package_name_stdout.addStepDependencies(&builtin_options_update.step);
+    }
+
+    /// make for zig 0.13.0
+    fn make013(step: *Step, prog_node: std.Progress.Node) !void {
+        _ = prog_node; // autofix
+        try make(step);
+    }
+
+    /// make for zig 0.14.0+
+    fn makeLatest(step: *Step, options: Build.Step.MakeOptions) !void {
+        _ = options; // autofix
+        try make(step);
+    }
+
+    fn make(step: *Step) !void {
+        const b = step.owner;
+        const builtin_options_update: *@This() = @fieldParentPtr("step", step);
+        const options = builtin_options_update.options;
+
+        const package_name_path = builtin_options_update.package_name_stdout.getPath2(b, step);
+
+        const file = try fs.openFileAbsolute(package_name_path, .{});
+
+        // Read package name from stdout and strip line feed / carriage return
+        // ie. "com.zig.sdl2\n\r"
+        const package_name_filedata = try file.readToEndAlloc(b.allocator, 8192);
+        const package_name_stripped = std.mem.trimRight(u8, package_name_filedata, " \r\n");
+        const package_name: [:0]const u8 = try b.allocator.dupeZ(u8, package_name_stripped);
+
+        options.addOption([:0]const u8, "package_name", package_name);
+    }
+};


### PR DESCRIPTION
- update resources to no longer use WriteFiles and just compile directly with `aapt2 compile`
- bake package_name into the Zig `android` package so it can always log with the correct tag name 
   - ie. even if SDL starts your code from a new thread

**Things that didn't work out:**
- exploring outputting the APK contents to a directory, this failed to work