### PR TITLE
switch to translate-c for SDL2 to avoid use of usingnamespace

### DIFF
--- a/examples/sdl2/third-party/sdl2/src/sdl.h
+++ b/examples/sdl2/third-party/sdl2/src/sdl.h
@@ -1,0 +1,1 @@
+#include <SDL.h>

--- a/examples/sdl2/third-party/sdl2/src/sdl.zig
+++ b/examples/sdl2/third-party/sdl2/src/sdl.zig
@@ -1,3 +1,0 @@
-pub usingnamespace @cImport({
-    @cInclude("SDL.h");
-});


### PR DESCRIPTION
There's a proposal to remove `usingnamespace` here: https://github.com/ziglang/zig/issues/20663
I think in general avoiding `usingnamespace` where possible is ideal.