### PR TITLE
Fix "Targeting R+ (version 30 and above) requires the resources.arsc of installed APKs to be stored uncompressed"

### DIFF
--- a/examples/minimal/build.zig
+++ b/examples/minimal/build.zig
@@ -37,16 +37,19 @@ pub fn build(b: *std.Build) void {
     };
 
     for (targets) |target| {
-        var exe: *std.Build.Step.Compile = if (target.result.abi.isAndroid()) b.addSharedLibrary(.{
-            .name = exe_name,
-            .root_source_file = b.path("src/minimal.zig"),
+        const app_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .root_source_file = b.path("src/minimal.zig"),
+        });
+
+        var exe: *std.Build.Step.Compile = if (target.result.abi.isAndroid()) b.addLibrary(.{
+            .name = exe_name,
+            .root_module = app_module,
+            .linkage = .dynamic,
         }) else b.addExecutable(.{
             .name = exe_name,
-            .root_source_file = b.path("src/minimal.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = app_module,
         });
 
         // if building as library for Android, add this target

--- a/examples/sdl2/build.zig
+++ b/examples/sdl2/build.zig
@@ -56,16 +56,18 @@ pub fn build(b: *std.Build) void {
 
     for (targets) |target| {
         const exe_name: []const u8 = "sdl-zig-demo";
-        var exe: *std.Build.Step.Compile = if (target.result.abi.isAndroid()) b.addSharedLibrary(.{
-            .name = exe_name,
-            .root_source_file = b.path("src/sdl-zig-demo.zig"),
+        const app_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .root_source_file = b.path("src/sdl-zig-demo.zig"),
+        });
+        var exe: *std.Build.Step.Compile = if (target.result.abi.isAndroid()) b.addLibrary(.{
+            .name = exe_name,
+            .root_module = app_module,
+            .linkage = .dynamic,
         }) else b.addExecutable(.{
             .name = exe_name,
-            .root_source_file = b.path("src/sdl-zig-demo.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = app_module,
         });
 
         const library_optimize = if (!target.result.abi.isAndroid())


### PR DESCRIPTION
Fix "Targeting R+ (version 30 and above) requires the resources.arsc of installed APKs to be stored uncompressed"

Resolving this issue was made much easier thanks to @ousttrue here with their fork here:
https://github.com/ousttrue/zig-android-sdk/commit/a741b6268404592312a4123c3f6b565734d56501

Fixes #23 