### PR TITLE
fix bug where if NDK version isn't installed, you get a panic rather than a nice error message

### DIFF
--- a/src/androidbuild/apk.zig
+++ b/src/androidbuild/apk.zig
@@ -71,7 +71,11 @@ pub fn create(sdk: *Sdk, options: Options) *Apk {
         error.NdkFailed => Ndk.empty, // fallthrough and print all errors below
         error.OutOfMemory => @panic("OOM"),
     };
-    ndk.validateApiLevel(b, options.api_level, &errors);
+    if (ndk.path.len != 0) {
+        // Only do additional NDK validation if ndk is not set to Ndk.empty
+        // ie. "ndk_version" isn't installed
+        ndk.validateApiLevel(b, options.api_level, &errors);
+    }
     if (errors.items.len > 0) {
         printErrorsAndExit("unable to find required Android installation", errors.items);
     }


### PR DESCRIPTION
fix bug raised on Github Issue #41 where if NDK version isn't installed, you get a panic rather than a nice error message

Fixes #41