### PR TITLE
Update logging writer to support Zig 0.15.x-dev (post-Writergate support)

### DIFF
--- a/src/android/android.zig
+++ b/src/android/android.zig
@@ -286,9 +286,6 @@ const Panic = struct {
     /// The counter is incremented/decremented atomically.
     var panicking = std.atomic.Value(u8).init(0);
 
-    // Locked to avoid interleaving panic messages from multiple threads.
-    var panic_mutex = std.Thread.Mutex{};
-
     /// Counts how many times the panic handler is invoked by this thread.
     /// This is used to catch and handle panics triggered by the panic handler.
     threadlocal var panic_stage: usize = 0;
@@ -404,8 +401,6 @@ const Panic = struct {
 
                 // Make sure to release the mutex when done
                 {
-                    panic_mutex.lock();
-                    defer panic_mutex.unlock();
                     if (builtin.single_threaded) {
                         _ = __android_log_print(
                             @intFromEnum(Level.fatal),


### PR DESCRIPTION
**Why?**

Writer interface was changed and broken, need to update the Android SDK to support 0.14.1 vs 0.15.x-dev

**Related to breaking change here:**
https://github.com/ziglang/zig/pull/24329