### PR TITLE
Update `ArrayList` usage for Zig 0.15.1.

### DIFF
--- a/src/androidbuild/BuildTools.zig
+++ b/src/androidbuild/BuildTools.zig
@@ -20,7 +20,7 @@ pub const empty: BuildTools = .{
 
 const BuildToolError = Allocator.Error || error{BuildToolFailed};
 
-pub fn init(b: *std.Build, android_sdk_path: []const u8, build_tools_version: []const u8, errors: *std.ArrayList([]const u8)) BuildToolError!BuildTools {
+pub fn init(b: *std.Build, android_sdk_path: []const u8, build_tools_version: []const u8, errors: *std.ArrayListUnmanaged([]const u8)) BuildToolError!BuildTools {
     const prev_errors_len = errors.items.len;
 
     // Get build tools path
@@ -38,14 +38,14 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, build_tools_version: []
             const message = b.fmt("Android Build Tool version '{s}' not found. Install it via 'sdkmanager' or Android Studio.", .{
                 build_tools_version,
             });
-            errors.append(message) catch @panic("OOM");
+            errors.append(b.allocator, message) catch @panic("OOM");
         },
         else => {
             const message = b.fmt("Android Build Tool version '{s}' had unexpected error: {s}", .{
                 build_tools_version,
                 @errorName(err),
             });
-            errors.append(message) catch @panic("OOM");
+            errors.append(b.allocator, message) catch @panic("OOM");
         },
     };
     if (errors.items.len != prev_errors_len) {

--- a/src/androidbuild/Ndk.zig
+++ b/src/androidbuild/Ndk.zig
@@ -28,7 +28,7 @@ pub const empty: Ndk = .{
 
 const NdkError = Allocator.Error || error{NdkFailed};
 
-pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8, errors: *std.ArrayList([]const u8)) NdkError!Ndk {
+pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8, errors: *std.ArrayListUnmanaged([]const u8)) NdkError!Ndk {
     // Get NDK path
     // ie. $ANDROID_HOME/ndk/27.0.12077973
     const android_ndk_path = b.fmt("{s}/ndk/{s}", .{ android_sdk_path, ndk_version });
@@ -39,7 +39,7 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8
                 const message = b.fmt("Android NDK version '{s}' not found. Install it via 'sdkmanager' or Android Studio.", .{
                     ndk_version,
                 });
-                try errors.append(message);
+                try errors.append(b.allocator, message);
                 break :blk false;
             },
             else => {
@@ -48,7 +48,7 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8
                     @errorName(err),
                     android_ndk_path,
                 });
-                try errors.append(message);
+                try errors.append(b.allocator, message);
                 break :blk false;
             },
         };
@@ -82,7 +82,7 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8
                     ndk_version,
                     ndk_sysroot,
                 });
-                try errors.append(message);
+                try errors.append(b.allocator, message);
                 break :blk false;
             },
             else => {
@@ -91,7 +91,7 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8
                     @errorName(err),
                     ndk_sysroot,
                 });
-                try errors.append(message);
+                try errors.append(b.allocator, message);
                 break :blk false;
             },
         };
@@ -111,7 +111,7 @@ pub fn init(b: *std.Build, android_sdk_path: []const u8, ndk_version: []const u8
     return ndk;
 }
 
-pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, errors: *std.ArrayList([]const u8)) void {
+pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, errors: *std.ArrayListUnmanaged([]const u8)) void {
     if (ndk.android_sdk_path.len == 0 or ndk.sysroot_path.len == 0) {
         @panic("Should not call validateApiLevel if NDK path is not set");
     }
@@ -128,7 +128,7 @@ pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, err
                     @intFromEnum(api_level),
                     ndk_sysroot_target_api_version,
                 });
-                errors.append(message) catch @panic("OOM");
+                errors.append(b.allocator, message) catch @panic("OOM");
                 break :blk false;
             },
             else => {
@@ -138,7 +138,7 @@ pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, err
                     @errorName(err),
                     ndk_sysroot_target_api_version,
                 });
-                errors.append(message) catch @panic("OOM");
+                errors.append(b.allocator, message) catch @panic("OOM");
                 break :blk false;
             },
         };
@@ -160,7 +160,7 @@ pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, err
                     @intFromEnum(api_level),
                     root_jar,
                 });
-                errors.append(message) catch @panic("OOM");
+                errors.append(b.allocator, message) catch @panic("OOM");
                 break :blk false;
             },
             else => {
@@ -169,7 +169,7 @@ pub fn validateApiLevel(ndk: *const Ndk, b: *std.Build, api_level: ApiLevel, err
                     @errorName(err),
                     root_jar,
                 });
-                errors.append(message) catch @panic("OOM");
+                errors.append(b.allocator, message) catch @panic("OOM");
                 break :blk false;
             },
         };

--- a/src/androidbuild/tools.zig
+++ b/src/androidbuild/tools.zig
@@ -84,18 +84,18 @@ pub fn create(b: *std.Build, options: Options) *Sdk {
     const jdk_path = path_search.findJDK(b.allocator) catch @panic("OOM");
 
     // Validate
-    var errors = std.ArrayList([]const u8).init(b.allocator);
-    defer errors.deinit();
+    var errors = std.ArrayListUnmanaged([]const u8).empty;
+    defer errors.deinit(b.allocator);
 
     if (jdk_path.len == 0) {
-        errors.append(
+        errors.append(b.allocator,
             \\JDK not found.
             \\- Download it from https://www.oracle.com/th/java/technologies/downloads/
             \\- Then configure your JDK_HOME environment variable to where you've installed it.
         ) catch @panic("OOM");
     }
     if (android_sdk_path.len == 0) {
-        errors.append(
+        errors.append(b.allocator,
             \\Android SDK not found.
             \\- Download it from https://developer.android.com/studio
             \\- Then configure your ANDROID_HOME environment variable to where you've installed it."
@@ -120,14 +120,14 @@ pub fn create(b: *std.Build, options: Options) *Sdk {
                             cmdline_tools,
                             tools,
                         });
-                        errors.append(message) catch @panic("OOM");
+                        errors.append(b.allocator, message) catch @panic("OOM");
                     },
                     else => {
                         const message = b.fmt("Android Command Line Tools path had unexpected error: {s} ({s})", .{
                             @errorName(toolerr),
                             tools,
                         });
-                        errors.append(message) catch @panic("OOM");
+                        errors.append(b.allocator, message) catch @panic("OOM");
                     },
                 };
             },
@@ -136,7 +136,7 @@ pub fn create(b: *std.Build, options: Options) *Sdk {
                     @errorName(cmderr),
                     cmdline_tools,
                 });
-                errors.append(message) catch @panic("OOM");
+                errors.append(b.allocator, message) catch @panic("OOM");
             },
         };
         break :cmdlineblk cmdline_tools;


### PR DESCRIPTION
The previous style of an `ArrayList` with an allocator field has been deprecated. In Zig 0.15.1 `ArrayList` is just `ArrayListUnmanaged`. I Decided to use `ArrayListUnmanged` for compatibility with older Zig versions, these could probably get changed to just `ArrayList` in the future.