### PR TITLE
use @trap instead of posix.abort in custom panic handler

### DIFF
--- a/src/android/android.zig
+++ b/src/android/android.zig
@@ -445,7 +445,7 @@ const Panic = struct {
             },
         };
 
-        posix.abort();
+        @trap();
     }
 
     fn dumpStackTrace(stack_trace: std.builtin.StackTrace) void {


### PR DESCRIPTION
Change custom panic handler to use @trap instead of posix.abort

Supposedly this does a better job of providing error messaging and while I haven't personally confirmed this, I see no reason not to make the switch for now.

> I found that using @trap() instead of abort in the custom panicHandler does a better job

```sh
Fatal signal 4 (SIGILL), code 1 (ILL_ILLOPC), fault addr 0x8b3dad4c in tid 30692 (com.zig.android), pid 30647 (com.zig.android)
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'motorola/malta_l/malta:10/QOLS30.288-52-23/2c2b6:user/release-keys'
Revision: '0'
ABI: 'arm'
Timestamp: 2023-03-11 21:50:17-0300
pid: 30647, tid: 30692, name: com.zig.android  >>> com.zig.android <<<
uid: 10195
signal 4 (SIGILL), code 1 (ILL_ILLOPC), fault addr 0x8b3dad4c (*pc=0xe7ffdefe)
Abort message: 'panic: !'
    r0  00000000  r1  ffffffff  r2  00000054  r3  8b4d6cf0
    r4  8b151408  r5  8b152230  r6  8b152230  r7  00000078
    r8  000077b7  r9  000077b7  r10 b6307020  r11 8b152040
    ip  00000011  sp  8b14f388  lr  8b4d7240  pc  8b3dad4c

backtrace:
      #00 pc 000fbd4c  /data/app/com.zig.android/lib/arm/libgame.so!libgame.so (offset 0xf5000)
      #01 pc 001f823c  /data/app/com.zig.android/lib/arm/libgame.so!libgame.so (offset 0xf5000) (array_hash_map.ArrayHashMapUnmanaged(u64,debug.Dwarf.CompileUnit.SrcLocCache.LineEntry,array_hash_map.AutoContext(u64),false).getOrPutInternal__anon_61580+256)
      #02 pc 0013d678  /data/app/com.zig.android/lib/arm/libgame.so!libgame.so (offset 0xf5000) (android.App.immersiveMode+8912)
      #03 pc 001334bc  /data/app/com.zig.android/lib/arm/libgame.so!libgame.so (offset 0xf5000) (fmt.format_float.pow5Factor__anon_8708+244)
      #04 pc 00130690  /data/app/com.zig.android/lib/arm/libgame.so!libgame.so (offset 0xf5000) (fmt.format_float.writeDecimal__anon_8155+4220)
      #05 pc 000a60b3  /apex/com.android.runtime/lib/bionic/libc.so (__pthread_start(void*)+20) (BuildId: 4431b35d55c1d9b5f8568451110b8281)
      #06 pc 00060783  /apex/com.android.runtime/lib/bionic/libc.so (__start_thread+30) (BuildId: 4431b35d55c1d9b5f8568451110b8281)
glue: no `onPause`
```

Related to https://github.com/silbinarywolf/zig-android-sdk/issues/54