### PR TITLE
Improve asset directory to support generated directories

### DIFF
--- a/examples/sdl2/build.zig
+++ b/examples/sdl2/build.zig
@@ -37,6 +37,10 @@ pub fn build(b: *std.Build) void {
         const key_store_file = android_sdk.createKeyStore(.example);
         apk.setKeyStore(key_store_file);
         apk.setAndroidManifest(b.path("android/AndroidManifest.xml"));
+
+        const generated_asset_dir = b.addNamedWriteFiles("android_asset_directory");
+        _ = generated_asset_dir.addCopyFile(b.path("src/zig.bmp"), "zig.bmp");
+        apk.addAssetDirectory(generated_asset_dir.getDirectory());
         apk.addResourceDirectory(b.path("android/res"));
 
         // Add Java files

--- a/examples/sdl2/src/sdl-zig-demo.zig
+++ b/examples/sdl2/src/sdl-zig-demo.zig
@@ -69,11 +69,12 @@ pub fn main() !void {
     };
     defer sdl.SDL_DestroyRenderer(renderer);
 
-    const zig_bmp = @embedFile("zig.bmp");
-    const rw = sdl.SDL_RWFromConstMem(zig_bmp, zig_bmp.len) orelse {
-        log.info("Unable to get RWFromConstMem: {s}", .{sdl.SDL_GetError()});
-        return error.SDLInitializationFailed;
-    };
+    const rw = sdl.SDL_RWFromFile(if (builtin.abi.isAndroid())
+        // For Android, we setup the build to dynamically add "zig.bmp" to the Android assets folder
+        // so it's accessible without "src/" prefix
+        "zig.bmp"
+    else
+        "src/zig.bmp", "rb");
     defer assert(sdl.SDL_RWclose(rw) == 0);
 
     const zig_surface = sdl.SDL_LoadBMP_RW(rw, 0) orelse {

--- a/examples/sdl2/third-party/sdl2/build.zig
+++ b/examples/sdl2/third-party/sdl2/build.zig
@@ -266,7 +266,7 @@ const generic_src_files = [_][]const u8{
     "src/stdlib/SDL_malloc.c",
     "src/stdlib/SDL_mslibc.c",
     "src/stdlib/SDL_qsort.c",
-    //"src/stdlib/SDL_stdmod.c", // Removed between 2.32.2 and 2.32.10
+    "src/stdlib/SDL_stdlib.c", // "src/stdlib/SDL_stdmod.c", // Renamed between 2.32.2 and 2.32.10
     "src/stdlib/SDL_string.c",
     "src/stdlib/SDL_strtokr.c",
     "src/thread/SDL_thread.c",

--- a/src/androidbuild/DirectoryFileInput.zig
+++ b/src/androidbuild/DirectoryFileInput.zig
@@ -1,0 +1,76 @@
+//! DirectoryFileInput adds files within a directory to the dependencies of the given Step.Run command
+//! This is required so that generated directories will work.
+
+const std = @import("std");
+const androidbuild = @import("androidbuild.zig");
+const builtin = @import("builtin");
+const Build = std.Build;
+const Step = Build.Step;
+const Run = Build.Step.Run;
+const LazyPath = Build.LazyPath;
+const fs = std.fs;
+const mem = std.mem;
+const assert = std.debug.assert;
+
+step: Step,
+
+/// Runner to update
+run: *Build.Step.Run,
+
+/// The directory that will contain the files to glob
+dir: LazyPath,
+
+pub fn create(owner: *std.Build, run: *Run, dir: LazyPath) void {
+    const self = owner.allocator.create(DirectoryFileInput) catch @panic("OOM");
+    self.* = .{
+        .step = Step.init(.{
+            .id = .custom,
+            .name = androidbuild.runNameContext("directory-file-input"),
+            .owner = owner,
+            .makeFn = make,
+        }),
+        .run = run,
+        .dir = dir,
+    };
+    // Run step relies on DirectoryFileInput finishing
+    run.step.dependOn(&self.step);
+    // If dir is generated then this will wait for that dir to generate
+    dir.addStepDependencies(&self.step);
+}
+
+fn make(step: *Step, _: Build.Step.MakeOptions) !void {
+    const b = step.owner;
+    const arena = b.allocator;
+    const self: *DirectoryFileInput = @fieldParentPtr("step", step);
+
+    const run = self.run;
+    const dir_path = self.dir.getPath3(b, step);
+
+    // NOTE(jae): 2025-07-23
+    // As of Zig 0.15.0-dev.1092+d772c0627, package_name_path.openDir("") is not possible as it assumes you're appending a sub-path
+    var dir = if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15)
+        try dir_path.root_dir.handle.openDir(dir_path.sub_path, .{ .iterate = true })
+    else
+        try dir_path.root_dir.handle.openDir(b.graph.io, dir_path.sub_path, .{ .iterate = true });
+    defer if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15)
+        dir.close()
+    else
+        dir.close(b.graph.io);
+
+    var walker = try dir.walk(arena);
+    defer walker.deinit();
+    while (if (builtin.zig_version.major == 0 and builtin.zig_version.minor <= 15)
+        try walker.next()
+    else
+        try walker.next(b.graph.io)) |entry|
+    {
+        if (entry.kind != .file) continue;
+
+        // Add file as dependency to run command
+        run.addFileInput(LazyPath{
+            .cwd_relative = try dir_path.root_dir.join(b.allocator, &.{ dir_path.sub_path, entry.path }),
+        });
+    }
+}
+
+const DirectoryFileInput = @This();


### PR DESCRIPTION
**Whats changed?**

We now have a build step called `DirectoryFileInput` which has a dependency on the directory given to it, we then make the `aapt2link` run command have a dependency on the `DirectoryFileInput` build step.

This means that:
- `aapt2link` will wait for `DirectoryFileInput` to complete
- This means `DirectoryFileInput` can resolve the lazy path of the directory and add the file inputs to `aapt2link` when the directory is "ready".

**Changes**
- Update asset and resources directory to automatically recursively add each file in a sub-folder as a file dependency to the run action.
- Fix SDL2 example being broken after previous version bump on Zig 0.15.2

**Testing completed**
- SDL2 example with Zig 0.15.2 on Linux via Android Studio
- Zig.bmp asset shows up in *.apk
<img width="340" height="952" alt="image" src="https://github.com/user-attachments/assets/36c85ce8-4fa5-4a84-8d64-25bb576f48b4" />

<img width="1210" height="668" alt="image" src="https://github.com/user-attachments/assets/f6a92d77-6d18-4f3e-8b48-e24dff4e6ec1" />


Fixes #66