### PR TITLE
Force the replacement of an existing application

### DIFF
--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -13,7 +13,7 @@ zig build run -Dandroid # Android
 
 ```sh
 zig build -Dtarget=x86_64-linux-android
-adb install ./zig-out/bin/minimal.apk
+adb install -r ./zig-out/bin/minimal.apk
 adb shell am start -S -W -n com.zig.minimal/android.app.NativeActivity
 ```
 
@@ -21,7 +21,7 @@ adb shell am start -S -W -n com.zig.minimal/android.app.NativeActivity
 
 ```sh
 zig build -Dandroid
-adb install ./zig-out/bin/minimal.apk
+adb install -r ./zig-out/bin/minimal.apk
 ```
 
 ### Uninstall your application

--- a/examples/raylib/README.md
+++ b/examples/raylib/README.md
@@ -18,7 +18,7 @@ zig build run -Dandroid # Android
 
 ```sh
 zig build -Dtarget=x86_64-linux-android
-adb install ./zig-out/bin/raylib.apk
+adb install -r ./zig-out/bin/raylib.apk
 adb shell am start -S -W -n com.zig.raylib/android.app.NativeActivity
 ```
 
@@ -26,7 +26,7 @@ adb shell am start -S -W -n com.zig.raylib/android.app.NativeActivity
 
 ```sh
 zig build -Dandroid
-adb install ./zig-out/bin/raylib.apk
+adb install -r ./zig-out/bin/raylib.apk
 ```
 
 ### Uninstall your application

--- a/examples/sdl2/README.md
+++ b/examples/sdl2/README.md
@@ -13,7 +13,7 @@ zig build run -Dandroid # Android
 
 ```sh
 zig build -Dtarget=x86_64-linux-android
-adb install ./zig-out/bin/sdl-zig-demo.apk
+adb install -r ./zig-out/bin/sdl-zig-demo.apk
 adb shell am start -S -W -n com.zig.sdl2/com.zig.sdl2.ZigSDLActivity
 ```
 
@@ -21,7 +21,7 @@ adb shell am start -S -W -n com.zig.sdl2/com.zig.sdl2.ZigSDLActivity
 
 ```sh
 zig build -Dandroid=true
-adb install ./zig-out/bin/sdl-zig-demo.apk
+adb install -r ./zig-out/bin/sdl-zig-demo.apk
 ```
 
 ### Uninstall your application

--- a/src/androidbuild/tools.zig
+++ b/src/androidbuild/tools.zig
@@ -199,7 +199,7 @@ pub fn addAdbStart(sdk: *Sdk, package_name_and_java_entry: []const u8) *Step.Run
 }
 
 /// Install an APK onto your Android device or emulator
-/// ie. "adb install ./zig-out/bin/minimal.apk"
+/// ie. "adb install -r ./zig-out/bin/minimal.apk"
 pub fn adbInstall(sdk: *Sdk, apk: LazyPath) void {
     const b = sdk.b;
     const adb_install = sdk.addAdbInstall(apk);
@@ -207,7 +207,7 @@ pub fn adbInstall(sdk: *Sdk, apk: LazyPath) void {
 }
 
 /// Install an APK onto your Android device or emulator
-/// ie. "adb install ./zig-out/bin/minimal.apk"
+/// ie. "adb install -r ./zig-out/bin/minimal.apk"
 pub fn addAdbInstall(sdk: *Sdk, apk: LazyPath) *Step.Run {
     const b = sdk.b;
     if (sdk.platform_tools.adb.len == 0) {
@@ -217,6 +217,7 @@ pub fn addAdbInstall(sdk: *Sdk, apk: LazyPath) *Step.Run {
         sdk.platform_tools.adb,
         "install",
     });
+    adb_install.addArg("-r");
     adb_install.addFileArg(apk);
     return adb_install;
 }


### PR DESCRIPTION
This just circumvents the need for manually uninstalling the application. I'd leave the instructions in the examples' `README.md` since it's useful to see how to uninstall the application, but it's likely not a needed step anymore.

From `adb`'s manual:
```
APP INSTALLATION
     -r:     Replace existing application.
```

The flag is there since [at least 2012](https://stackoverflow.com/a/12028196) so a compatibility check isn't needed since there aren't any for e.g. `dx` which is not available since NDK 30 (or somewhere around that time).