### PR TITLE
Fix scoped log

### DIFF
--- a/src/android/android.zig
+++ b/src/android/android.zig
@@ -53,7 +53,7 @@ fn androidLogFn(
         comptime std.mem.indexOfScalar(u8, format, '{') == null)
     {
         // If no formatting, log string directly with Android logging
-        _ = Logger.logString(android_log_level, format);
+        _ = Logger.logString(android_log_level, scope_prefix_text ++ format);
         return;
     }
     var buffer: [8192]u8 = undefined;

--- a/src/android/zig015/zig015.zig
+++ b/src/android/zig015/zig015.zig
@@ -15,7 +15,7 @@ pub fn wrapLogFn(comptime logFn: fn (
             // NOTE(jae): 2024-09-11
             // Zig has a colon ": " or "): " for scoped but Android logs just do that after being flushed
             // So we don't do that here.
-            const scope_prefix_text = if (scope == .default) "" else "(" ++ @tagName(scope) ++ ")"; // "): ";
+            const scope_prefix_text = if (scope == .default) "" else @tagName(scope) ++ ": ";
             return logFn(message_level, scope_prefix_text, format, args);
         }
     }.standardLogFn;

--- a/src/android/zig016/zig016.zig
+++ b/src/android/zig016/zig016.zig
@@ -20,7 +20,7 @@ pub fn wrapLogFn(comptime logFn: fn (
             // NOTE(jae): 2024-09-11
             // Zig has a colon ": " or "): " for scoped but Android logs just do that after being flushed
             // So we don't do that here.
-            const scope_prefix_text = if (scope == .default) "" else "(" ++ @tagName(scope) ++ ")"; // "): ";
+            const scope_prefix_text = if (scope == .default) "" else @tagName(scope) ++ ": ";
             return logFn(message_level, scope_prefix_text, format, args);
         }
     }.standardLogFn;


### PR DESCRIPTION
Fixes scope being ignored if there is no formatting, and changes the scope prefix.

before:
`04-01 18:13:15.911   856   896 I sleepy.wio.demo: (scope)beep`
after:
`04-01 18:13:15.911   856   896 I sleepy.wio.demo: scope: beep`