### PR TITLE
Set APK name explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ const android = @import("android");
 pub fn build(b: *std.Build) !void {
     const android_sdk = android.Sdk.create(b, .{});
     const apk = android_sdk.createApk(.{
+        .name = "example",
         .api_level = .android15,
         .build_tools_version = "35.0.1",
         .ndk_version = "29.0.13113456",
@@ -28,12 +29,15 @@ pub fn build(b: *std.Build) !void {
     apk.addResourceDirectory(b.path("android/res"));
     apk.addJavaSourceFile(.{ .file = b.path("android/src/NativeInvocationHandler.java") });
     for (android.standardTargets(b, b.standardTargetOptions(.{}))) |target| {
-        apk.addArtifact(b.addSharedLibrary(.{
-            .name = exe_name,
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        }))
+        apk.addArtifact(b.addLibrary(.{
+            .name = "main",
+            .linkage = .dynamic,
+            .root_module = b.createModule(
+                .root_source_file = b.path("src/main.zig"),
+                .target = target,
+                .optimize = optimize,
+            ),
+        }));
     }
 }
 ```

--- a/examples/minimal/build.zig
+++ b/examples/minimal/build.zig
@@ -19,6 +19,7 @@ pub fn build(b: *std.Build) void {
 
         const android_sdk = android.Sdk.create(b, .{});
         const apk = android_sdk.createApk(.{
+            .name = exe_name,
             .api_level = .android15,
             .build_tools_version = "35.0.1",
             .ndk_version = "29.0.13113456",
@@ -50,7 +51,7 @@ pub fn build(b: *std.Build) void {
         });
 
         var exe: *std.Build.Step.Compile = if (target.result.abi.isAndroid()) b.addLibrary(.{
-            .name = exe_name,
+            .name = "main",
             .root_module = app_module,
             .linkage = .dynamic,
         }) else b.addExecutable(.{

--- a/examples/raylib/build.zig
+++ b/examples/raylib/build.zig
@@ -2,9 +2,8 @@ const std = @import("std");
 const android = @import("android");
 const LinkMode = std.builtin.LinkMode;
 
-const exe_name = "raylib";
-
 pub fn build(b: *std.Build) void {
+    const exe_name = "raylib";
     const root_target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const android_targets = android.standardTargets(b, root_target);
@@ -20,6 +19,7 @@ pub fn build(b: *std.Build) void {
 
         const android_sdk = android.Sdk.create(b, .{});
         const apk = android_sdk.createApk(.{
+            .name = exe_name,
             .api_level = .android15,
             .build_tools_version = "35.0.1",
             .ndk_version = "29.0.13113456",
@@ -72,7 +72,7 @@ pub fn build(b: *std.Build) void {
 
             apk.addArtifact(b.addLibrary(.{
                 .linkage = .dynamic,
-                .name = exe_name,
+                .name = "main",
                 .root_module = app,
             }));
         } else {

--- a/examples/sdl2/build.zig
+++ b/examples/sdl2/build.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const android = @import("android");
 
 pub fn build(b: *std.Build) void {
+    const exe_name: []const u8 = "sdl-zig-demo";
     const root_target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const android_targets = android.standardTargets(b, root_target);
@@ -20,6 +21,7 @@ pub fn build(b: *std.Build) void {
 
         const android_sdk = android.Sdk.create(b, .{});
         const apk = android_sdk.createApk(.{
+            .name = exe_name,
             .api_level = .android15,
             .build_tools_version = "36.1.0",
             .ndk_version = "29.0.14206865",
@@ -68,7 +70,6 @@ pub fn build(b: *std.Build) void {
     };
 
     for (targets) |target| {
-        const exe_name: []const u8 = "sdl-zig-demo";
         const app_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
@@ -115,7 +116,7 @@ pub fn build(b: *std.Build) void {
             app_module.addImport("android", android_dep.module("android"));
 
             const exe_lib = b.addLibrary(.{
-                .name = exe_name,
+                .name = "main",
                 .root_module = app_module,
                 .linkage = .dynamic,
             });

--- a/src/androidbuild/Apk.zig
+++ b/src/androidbuild/Apk.zig
@@ -35,6 +35,8 @@ pub const Resource = union(enum) {
 };
 
 b: *std.Build,
+/// APK file output name, ie. "{name}.apk"
+name: []const u8,
 sdk: *Sdk,
 /// Path to Native Development Kit, this includes various C-code headers, libraries, and more.
 /// ie. $ANDROID_HOME/ndk/29.0.13113456
@@ -53,6 +55,8 @@ resources: std.ArrayListUnmanaged(Resource),
 assets: std.ArrayListUnmanaged(Resource),
 
 pub const Options = struct {
+    /// APK file output name, ie. "{name}.apk"
+    name: []const u8,
     /// ie. "35.0.0"
     build_tools_version: []const u8,
     /// ie. "27.0.12077973"
@@ -87,6 +91,7 @@ pub fn create(sdk: *Sdk, options: Options) *Apk {
     const apk: *Apk = b.allocator.create(Apk) catch @panic("OOM");
     apk.* = .{
         .b = b,
+        .name = options.name,
         .sdk = sdk,
         .ndk = ndk,
         .build_tools = build_tools,
@@ -477,7 +482,7 @@ fn doInstallApk(apk: *Apk) Allocator.Error!*Step.InstallFile {
             .x86 => "x86",
             else => @panic(b.fmt("unsupported or unhandled arch: {s}", .{@tagName(target.result.cpu.arch)})),
         };
-        _ = apk_files.addCopyFile(artifact.getEmittedBin(), b.fmt("lib/{s}/libmain.so", .{so_dir}));
+        _ = apk_files.addCopyFile(artifact.getEmittedBin(), b.fmt("lib/{s}/lib{s}.so", .{ so_dir, artifact.name }));
 
         // Add module
         // - If a module has no `root_source_file` (e.g you're only compiling C files using `addCSourceFiles`)
@@ -719,8 +724,6 @@ fn doInstallApk(apk: *Apk) Allocator.Error!*Step.InstallFile {
     // lint.setEnvironmentVariable("JAVA_HOME", apk.tools.jdk_path);
     // lint.addFileArg(android_manifest_file);
 
-    const apk_name = apk.artifacts.items[0].name;
-
     // Align contents of .apk (zip)
     const aligned_apk_file: LazyPath = blk: {
         var zipalign = b.addSystemCommand(&[_][]const u8{
@@ -748,7 +751,7 @@ fn doInstallApk(apk: *Apk) Allocator.Error!*Step.InstallFile {
         zipalign.addFileArg(zip_file);
         zipalign.step.dependOn(update_zip);
 
-        const apk_file = zipalign.addOutputFileArg(b.fmt("aligned-{s}.apk", .{apk_name}));
+        const apk_file = zipalign.addOutputFileArg(b.fmt("aligned-{s}.apk", .{apk.name}));
         break :blk apk_file;
     };
 
@@ -769,7 +772,7 @@ fn doInstallApk(apk: *Apk) Allocator.Error!*Step.InstallFile {
         break :blk signed_output_apk_file;
     };
 
-    const install_apk = b.addInstallBinFile(signed_apk_file, b.fmt("{s}.apk", .{apk_name}));
+    const install_apk = b.addInstallBinFile(signed_apk_file, b.fmt("{s}.apk", .{apk.name}));
     return install_apk;
 }
 


### PR DESCRIPTION
- Prevents link issues caused by renaming a library but not changing its SONAME
- Allows multiple artifacts to be added for the same architecture
- Fixes #39