### PR TITLE
Allow explicitly requesting all targets

### DIFF
--- a/examples/minimal/build.zig
+++ b/examples/minimal/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const exe_name: []const u8 = "minimal";
     const root_target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const android_targets = android.standardTargets(b, root_target);
+    const android_targets = android.standardTargets(b, root_target, null);
 
     var root_target_single = [_]std.Build.ResolvedTarget{root_target};
     const targets: []std.Build.ResolvedTarget = if (android_targets.len == 0)

--- a/examples/raylib/build.zig
+++ b/examples/raylib/build.zig
@@ -7,7 +7,7 @@ const exe_name = "raylib";
 pub fn build(b: *std.Build) void {
     const root_target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const android_targets = android.standardTargets(b, root_target);
+    const android_targets = android.standardTargets(b, root_target, null);
 
     var root_target_single = [_]std.Build.ResolvedTarget{root_target};
     const targets: []std.Build.ResolvedTarget = if (android_targets.len == 0)

--- a/examples/sdl2/build.zig
+++ b/examples/sdl2/build.zig
@@ -5,7 +5,7 @@ const android = @import("android");
 pub fn build(b: *std.Build) void {
     const root_target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const android_targets = android.standardTargets(b, root_target);
+    const android_targets = android.standardTargets(b, root_target, null);
 
     const crash_on_exception = b.option(bool, "crash-on-exception", "if true then we'll use the activity from androidCrashTest folder") orelse false;
 

--- a/src/androidbuild/androidbuild.zig
+++ b/src/androidbuild/androidbuild.zig
@@ -56,14 +56,13 @@ pub fn getAndroidTriple(target: ResolvedTarget) error{InvalidAndroidTarget}![]co
     };
 }
 
-/// Will return a slice of Android targets
-/// - If -Dandroid=true, return all Android targets (x86, x86_64, aarch64, etc)
-/// - If -Dtarget=aarch64-linux-android, return a slice with the one specified Android target
-///
-/// If none of the above, then return a zero length slice.
-pub fn standardTargets(b: *std.Build, target: ResolvedTarget) []ResolvedTarget {
-    const all_targets = b.option(bool, "android", "if true, build for all Android targets (x86, x86_64, aarch64, etc)") orelse false;
-    if (all_targets) {
+/// Return a slice of Android targets
+/// - If `all_targets` is true, returns all Android targets (x86, x86_64, aarch64, etc)
+/// - If `all_targets` is null and `-Dandroid=true`, returns all Android targets
+/// - If `target` uses the Android ABI, returns a slice with the specified target
+/// - Otherwise, returns a zero length slice
+pub fn standardTargets(b: *std.Build, target: ResolvedTarget, all_targets: ?bool) []ResolvedTarget {
+    if (all_targets orelse b.option(bool, "android", "if true, build for all Android targets (x86, x86_64, aarch64, etc)") orelse false) {
         return getAllAndroidTargets(b);
     }
     if (!target.result.abi.isAndroid()) {


### PR DESCRIPTION
My project uses zig-android-sdk as a lazy dependency, so I want to write something like:

```zig
const android_option = b.option(bool, "android", "Build for all Android targets") orelse false;

if (android_option or target.result.abi.isAndroid()) {
    if (b.lazyImport("android")) |android| {
        for (android.standardTargets(b, target)) |android_target| {
            // ...
        }
    }
}
```

but currently this doesn't work as a build option with a given name can only be declared once.