### PR TITLE
add resolveTargets function for improved lazy import support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,9 +8,6 @@ pub const resolveTargets = androidbuild.resolveTargets;
 pub const Apk = @import("src/androidbuild/Apk.zig");
 pub const Sdk = @import("src/androidbuild/tools.zig");
 
-// Expose Android build functionality for use in your build.zig
-
-// TODO: rename tools.zig to Sdk.zig
 // Deprecated exposed fields
 
 /// Deprecated: Use ApiLevel

--- a/build.zig
+++ b/build.zig
@@ -1,15 +1,16 @@
 const std = @import("std");
 const builtin = @import("builtin");
+
 const androidbuild = @import("src/androidbuild/androidbuild.zig");
+pub const ApiLevel = androidbuild.ApiLevel;
+pub const standardTargets = androidbuild.standardTargets;
+pub const resolveTargets = androidbuild.resolveTargets;
+pub const Apk = @import("src/androidbuild/Apk.zig");
+pub const Sdk = @import("src/androidbuild/tools.zig");
 
 // Expose Android build functionality for use in your build.zig
 
 // TODO: rename tools.zig to Sdk.zig
-pub const Sdk = @import("src/androidbuild/tools.zig");
-pub const Apk = @import("src/androidbuild/Apk.zig");
-pub const ApiLevel = androidbuild.ApiLevel;
-pub const standardTargets = androidbuild.standardTargets;
-
 // Deprecated exposed fields
 
 /// Deprecated: Use ApiLevel

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,5 @@
         "build.zig.zon",
         "src",
     },
-    .minimum_zig_version = "0.14.0",
     .fingerprint = 0x92bcb62d42fb2cee,
 }

--- a/src/androidbuild/Apk.zig
+++ b/src/androidbuild/Apk.zig
@@ -1,25 +1,23 @@
 const std = @import("std");
-const builtin = @import("builtin");
-const androidbuild = @import("androidbuild.zig");
-const Sdk = @import("tools.zig");
-const BuiltinOptionsUpdate = @import("BuiltinOptionsUpdate.zig");
-const DirectoryFileInput = @import("DirectoryFileInput.zig");
-
-const Ndk = @import("Ndk.zig");
-const BuildTools = @import("BuildTools.zig");
-const D8Glob = @import("D8Glob.zig");
-
-const KeyStore = Sdk.KeyStore;
-const ApiLevel = androidbuild.ApiLevel;
-const getAndroidTriple = androidbuild.getAndroidTriple;
-const runNameContext = androidbuild.runNameContext;
-const printErrorsAndExit = androidbuild.printErrorsAndExit;
-
 const Allocator = std.mem.Allocator;
 const Target = std.Target;
 const Step = std.Build.Step;
 const ResolvedTarget = std.Build.ResolvedTarget;
 const LazyPath = std.Build.LazyPath;
+const builtin = @import("builtin");
+
+const androidbuild = @import("androidbuild.zig");
+const ApiLevel = androidbuild.ApiLevel;
+const getAndroidTriple = androidbuild.getAndroidTriple;
+const runNameContext = androidbuild.runNameContext;
+const printErrorsAndExit = androidbuild.printErrorsAndExit;
+const BuildTools = @import("BuildTools.zig");
+const BuiltinOptionsUpdate = @import("BuiltinOptionsUpdate.zig");
+const D8Glob = @import("D8Glob.zig");
+const DirectoryFileInput = @import("DirectoryFileInput.zig");
+const Ndk = @import("Ndk.zig");
+const Sdk = @import("tools.zig");
+const KeyStore = Sdk.KeyStore;
 
 pub const Resource = union(enum) {
     // file: File,

--- a/src/androidbuild/androidbuild.zig
+++ b/src/androidbuild/androidbuild.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
-const builtin = @import("builtin");
-
 const Target = std.Target;
 const ResolvedTarget = std.Build.ResolvedTarget;
 const LazyPath = std.Build.LazyPath;
+const builtin = @import("builtin");
 
 const log = std.log.scoped(.@"zig-android-sdk");
 
@@ -62,10 +61,36 @@ pub fn getAndroidTriple(target: ResolvedTarget) error{InvalidAndroidTarget}![]co
 ///
 /// If none of the above, then return a zero length slice.
 pub fn standardTargets(b: *std.Build, target: ResolvedTarget) []ResolvedTarget {
+    // NOTE(jae): 2026-04-11
+    // Seperated logic into "resolveTargets" so that consumers of this library can create this option themselves and use "b.lazyImport"
+    // See: https://github.com/silbinarywolf/zig-android-sdk/pull/82
     const all_targets = b.option(bool, "android", "if true, build for all Android targets (x86, x86_64, aarch64, etc)") orelse false;
-    if (all_targets) {
+    return resolveTargets(b, .{
+        .default_target = target,
+        .all_targets = all_targets,
+    });
+}
+
+pub const ResolveTargetOptions = struct {
+    /// The target retrieved from b.standardTargetOptions
+    default_target: ResolvedTarget,
+    /// If true, then retrieve all Android targets rather than using the default target
+    all_targets: bool,
+
+    /// Shorthand to query all Android targets
+    pub const all: ResolveTargetOptions = .{
+        .default_target = undefined,
+        .all_targets = true,
+    };
+};
+
+/// Will return a slice of Android targets depending on the options given.
+/// Avoids setting up options
+pub fn resolveTargets(b: *std.Build, options: ResolveTargetOptions) []ResolvedTarget {
+    if (options.all_targets) {
         return getAllAndroidTargets(b);
     }
+    const target = options.default_target;
     if (!target.result.abi.isAndroid()) {
         return &[0]ResolvedTarget{};
     }

--- a/src/androidbuild/androidbuild.zig
+++ b/src/androidbuild/androidbuild.zig
@@ -64,7 +64,7 @@ pub fn standardTargets(b: *std.Build, target: ResolvedTarget) []ResolvedTarget {
     // NOTE(jae): 2026-04-11
     // Seperated logic into "resolveTargets" so that consumers of this library can create this option themselves and use "b.lazyImport"
     // See: https://github.com/silbinarywolf/zig-android-sdk/pull/82
-    const all_targets = b.option(bool, "android", "if true, build for all Android targets (x86, x86_64, aarch64, etc)") orelse false;
+    const all_targets = b.option(bool, "android", "Build for all Android targets (x86, x86_64, aarch64, arm, etc)") orelse false;
     return resolveTargets(b, .{
         .default_target = target,
         .all_targets = all_targets,


### PR DESCRIPTION
Based on request here: https://github.com/silbinarywolf/zig-android-sdk/pull/82

Example usage:
```zig
// Example usage in Zig 0.16.0-dev.3061+9b1eaad13
pub fn build(b: *std.Build) void {
    const exe_name: []const u8 = "minimal";
    const root_target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const all_android_targets = b.option(bool, "android", "Build for all Android targets (x86, x86_64, aarch64, arm, etc)") orelse false;
    const android_targets: []std.Build.ResolvedTarget = blk: {
        if (all_android_targets or root_target.result.abi.isAndroid()) {
            if (b.lazyImport(@This(), "android")) |android| {
                break :blk android.resolveTargets(b, .{
                    .default_target = root_target,
                    .all_targets = all_android_targets,
                });
            }
        }
        break :blk &[0]std.Build.ResolvedTarget{};
    };
```

I opted to look at how Zig separates build option creation for targets and took a similar route, for example Zig has `resolveTarget` for handling the logic without invoking `b.option`
```zig
/// Exposes standard `zig build` options for choosing a target and additionally
/// resolves the target query.
pub fn standardTargetOptions(b: *Build, args: StandardTargetOptionsArgs) ResolvedTarget {
    const query = b.standardTargetOptionsQueryOnly(args);
    return b.resolveTargetQuery(query);
}
```